### PR TITLE
fix: should include the block marked as FIRST

### DIFF
--- a/inc/Test/Base.pm
+++ b/inc/Test/Base.pm
@@ -459,6 +459,7 @@ sub _choose_blocks {
         next if exists $block->{SKIP};
         if ($has_first) {
             if (exists $block->{FIRST}) {
+                push @$blocks, $block;
                 $has_first = 0;
             }
             next;


### PR DESCRIPTION
Previously we start from FIRST + 1 block